### PR TITLE
fix to generate well-formed docutils document tree

### DIFF
--- a/sphinxcontrib/vcs.py
+++ b/sphinxcontrib/vcs.py
@@ -76,14 +76,17 @@ class GitDirective(BaseDirective):
 
     def get_changelog(self, repo, commit):
         item = nodes.list_item()
+        para = nodes.paragraph()
 
-        item.append(self._make_message_node(commit.message, commit.hexsha))
-        item.append(nodes.inline(text=' by '))
-        item.append(nodes.emphasis(text=commit.author.name))
-        item.append(nodes.inline(text=' at '))
+        para.append(self._make_message_node(commit.message, commit.hexsha))
+        para.append(nodes.inline(text=' by '))
+        para.append(nodes.emphasis(text=commit.author.name))
+        para.append(nodes.inline(text=' at '))
 
         commit_date = datetime.fromtimestamp(commit.authored_date)
-        item.append(nodes.emphasis(text=commit_date))
+        para.append(nodes.emphasis(text=commit_date))
+
+        item.append(para)
 
         if OPTION_WITH_REF_URL in self.options:
             ref_url = repo.get_commit_url(commit.hexsha)


### PR DESCRIPTION
In the Docutils DTD (http://docutils.sourceforge.net/docs/ref/doctree.html#list-item) list_item node contains body elements, but the nodes that sphinxcontrib-csv generates contains inline elements.

Because my extension builder (https://github.com/amedama41/docxbuilder) could not handle non well-formed tree like this, so I want to fix the generation tree.